### PR TITLE
fix: corrected faulty import for typescript config

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -10,7 +10,7 @@
 
 module.exports = {
 
-  extends: require.resolve('@strv/eslint-plugin-base'),
+  extends: require.resolve('@strv/eslint-config-base'),
 
   settings: {
     // Correctly recognise .ts and .d.ts files when checking import paths against the filesystem


### PR DESCRIPTION
`@strv/eslint-config-typescript` throws an error for me in a fresh project:

```
Error: Cannot read config file: /Users/andre/Projects/fore-honor/node_modules/@strv/eslint-config-typescript/index.js
Error: Cannot find module '@strv/eslint-plugin-base'
Referenced from: /Users/andre/Projects/fore-honor/package.json
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:613:15)
    at Function.resolve (internal/modules/cjs/helpers.js:28:19)
    at Object.<anonymous> (/Users/andre/Projects/fore-honor/node_modules/@strv/eslint-config-typescript/index.js:13:20)
    at Module._compile (internal/modules/cjs/loader.js:738:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:749:10)
    at Module.load (internal/modules/cjs/loader.js:630:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:570:12)
    at Function.Module._load (internal/modules/cjs/loader.js:562:3)
    at Module.require (internal/modules/cjs/loader.js:667:17)
    at require (internal/modules/cjs/helpers.js:20:18)
```

Looking at the other configs it seems that the wrong module was used. Updating the module to `@strv/eslint-config-base` fixes the problem for me. 
