### PR TITLE
Fix prettier package name

### DIFF
--- a/packages/prettier-config/readme.md
+++ b/packages/prettier-config/readme.md
@@ -1,3 +1,3 @@
-# `@strv/config-prettier`
+# `@strv/prettier-config`
 
 > STRV's ESLint config for Prettier


### PR DESCRIPTION
Should be `prettier-config` instead of `config-prettier` :slightly_smiling_face: 