### PR TITLE
Fix: faulty config in eslint-config-react/style

### DIFF
--- a/packages/eslint-config-react/style.js
+++ b/packages/eslint-config-react/style.js
@@ -17,7 +17,7 @@ module.exports = {
 
   rules: {
     // Enforce consistent usage of destructuring assignment of props, state, and context
-    'react/destructuring-assignment': ['warn', {
+    'react/destructuring-assignment': ['warn', 'always', {
       ignoreClassFields: true,
     }],
 


### PR DESCRIPTION
This change fixes the following issue:

```
 Error: @strv/eslint-config-react/style:
	Configuration for rule "react/destructuring-assignment" is invalid:
	Value {"ignoreClassFields":true} should be string.
```