### PR TITLE
fix: drop react/jsx-filename-extension rule 🔥

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -49,11 +49,6 @@ module.exports = {
     // Enforce the closing tag location for multiline JSX elements
     'react/jsx-closing-tag-location': ['warn'],
 
-    // Restrict file extensions that may contain JSX
-    'react/jsx-filename-extension': ['warn', {
-      extensions: ['.js', '.jsx'],
-    }],
-
     // Detect missing key prop
     // Warn if an element that likely requires a key prop--namely, one present in an array literal
     // or an arrow function expression.


### PR DESCRIPTION
File extensions do not play any role in deciding whether or not JSX is allowed/supported in a file; it's the build toolchain that decides this. Listing only specific extensions restricts users' ability to use for example JSX in TypeScript, or Flow files.

Fixes #13