### PR TITLE
fix: no-shadow builtinGlobals option

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -440,7 +440,7 @@ module.exports = {
     // Disallow Shadowing
     // This rule aims to eliminate shadowed variable declarations.
     'no-shadow': ['error', {
-      builtinGlobals: true,
+      builtinGlobals: false,
       hoist: 'functions',
     }],
 

--- a/packages/eslint-config-node/index.js
+++ b/packages/eslint-config-node/index.js
@@ -72,6 +72,13 @@ module.exports = {
       allowAtRootLevel: true,
     }],
 
+    // Disallow Shadowing
+    // This rule aims to eliminate shadowed variable declarations.
+    'no-shadow': ['error', {
+      builtinGlobals: true,
+      hoist: 'functions',
+    }],
+
     // Disallow unsupported ECMAScript features on the specified version
     // This rule reports unsupported ECMAScript built-in variables on the configured Node.js version
     // as lint errors. This rule reads the engines field of package.json to detect which Node.js


### PR DESCRIPTION
@robertrossmann @dannytce @danielkraus @prichodko  Hello 👋 🙂 I just noticed that we are using the following environments in our `.eslintrc`:

```
browser: true,
commonjs: true,
es6: true,
jest: true,
node: true,
```

However, in `@strv/eslint-config-react` we have `no-shadow` rule with `builtinGlobals` option set to `true`. https://github.com/strvcom/code-quality-tools/blob/b59ec331dedcd4b21b99187c1fa2e4702e5c79db/packages/eslint-config-base/index.js#L442

This prevents us from declaring many variables like `name` from `window.name` https://developer.mozilla.org/en-US/docs/Web/API/Window/name

I believe it makes sense to us `no-shadow` with `builtinGlobals: false` on the frontend. I am not sure about the backend. Maybe I can move the rule declaration into a different file so that we have different settings for frontend/backend? 🤔

![image](https://user-images.githubusercontent.com/14946081/54868421-8f830780-4d8c-11e9-96f8-26ccc083a8d7.png)
