### PR TITLE
fix: allow name exception in eslint no-shadow

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -442,6 +442,7 @@ module.exports = {
     'no-shadow': ['error', {
       builtinGlobals: true,
       hoist: 'functions',
+      allow: ['name'],
     }],
 
     // Disallow Undeclared Variables


### PR DESCRIPTION
@robertrossmann @dannytce @danielkraus @prichodko  Hello 👋 🙂 I just noticed that we are using the following environments in our `.eslintrc`:

```
browser: true,
commonjs: true,
es6: true,
jest: true,
node: true,
```

However, in `@strv/eslint-config-react` we have `no-shadow` rule with `builtinGlobals` option set to `true`. https://github.com/strvcom/code-quality-tools/blob/b59ec331dedcd4b21b99187c1fa2e4702e5c79db/packages/eslint-config-base/index.js#L442

This prevents us from declaring many variables like `name` from `window.name` https://developer.mozilla.org/en-US/docs/Web/API/Window/name

Adding exception for `name` should fix our problem. In the future we can add more exceptions for variables that are necessary but colide with `window` object.

![image](https://user-images.githubusercontent.com/14946081/54868421-8f830780-4d8c-11e9-96f8-26ccc083a8d7.png)
