### PR TITLE
feat: added no-unused-vars.ignoreRestSiblings

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -139,7 +139,7 @@ module.exports = {
     // This rule only has an effect when the no-unused-vars core rule is enabled. It ensures that
     // TypeScript-specific constructs, such as implemented interfaces, are not erroneously flagged
     // as unused.
-    '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { 'ignoreRestSiblings': true }],
 
     // Disallow the use of variables before they are defined
     // This rule will warn when it encounters a reference to an identifier that has not yet been


### PR DESCRIPTION
By default, destructured but unused variables are reported as errors. Many times, though, we use destructuring and rest operators to extract a portion of the original object which can be passed forward to another method. This option stops this errors.