### PR TITLE
TypeScript ruleset revision

### DIFF
--- a/packages/eslint-config-base/globs.js
+++ b/packages/eslint-config-base/globs.js
@@ -33,4 +33,11 @@ module.exports = {
     '*.mjs',
     '.*.mjs',
   ],
+
+  typescripts: [
+    '*.ts',
+    '.*.ts',
+    '*.tsx',
+    '.*.tsx',
+  ],
 }

--- a/packages/eslint-config-node/index.js
+++ b/packages/eslint-config-node/index.js
@@ -140,6 +140,11 @@ module.exports = {
     },
 
     rules: {
+      // Allow ES Modules to be used in these source files
+      'node/no-unsupported-features/es-syntax': ['error', {
+        ignores: ['modules'],
+      }],
+
       // Report modules without any exports & individual exports not being statically imported or
       // required from other modules in the same project
       'import/no-unused-modules': ['warn', {

--- a/packages/eslint-config-node/index.js
+++ b/packages/eslint-config-node/index.js
@@ -126,7 +126,10 @@ module.exports = {
       sourceType: 'script',
     },
   }, {
-    files: globs.esmodules,
+    files: [
+      ...globs.esmodules,
+      ...globs.typescripts,
+    ],
 
     parserOptions: {
       sourceType: 'module',
@@ -138,7 +141,7 @@ module.exports = {
 
     rules: {
       // Report modules without any exports & individual exports not being statically imported or
-      // requireed from other modules in the same project
+      // required from other modules in the same project
       'import/no-unused-modules': ['warn', {
         missingExports: true,
         unusedExports: true,

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -25,6 +25,8 @@ module.exports = {
           ...base.settings['import/resolver'].node.extensions,
         ],
       },
+      // Correctly recognise paths defined in tsconfig.json for package aliases
+      typescript: {},
     },
   },
 

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -44,6 +44,7 @@ module.exports = {
   },
 
   rules: {
+
     // TS code is mostly self-documented and having JSDoc directives for everything is redundant
     // when you can easily infer return values and argument types from the code itself.
     'valid-jsdoc': 'off',
@@ -56,9 +57,30 @@ module.exports = {
     // typescript specific declarations properly.
     'no-unused-vars': 'off',
 
+    'no-useless-constructor': 'off',
+
     // Require that member overloads be consecutive
     // Grouping overloaded members together can improve readability of the code.
     '@typescript-eslint/adjacent-overload-signatures': 'warn',
+
+    // Requires using either T[] or Array<T> for arrays
+    // This rule aims to standardise usage of array types within your codebase.
+    '@typescript-eslint/array-type': ['warn', {
+      default: 'array-simple',
+      readonly: 'array-simple',
+    }],
+
+    // Disallows awaiting a value that is not a Promise
+    // This rule disallows awaiting a value that is not a "Thenable" (an object which has then
+    // method, such as a Promise). While it is valid JavaScript to await a non-Promise-like value
+    // (it will resolve immediately), this pattern is often a programmer error, such as forgetting
+    // to add parenthesis to call a function that returns a Promise.
+    '@typescript-eslint/await-thenable': 'warn',
+
+    // Bans “// @ts-ignore” comments from being used
+    // Suppressing Typescript Compiler Errors can be hard to discover.
+    '@typescript-eslint/ban-ts-ignore': 'error',
+
 
     // Require PascalCased class and interface names
     // This rule aims to make it easy to differentiate classes from regular variables at a glance.
@@ -75,27 +97,14 @@ module.exports = {
 
     // Require explicit accessibility modifiers on class properties and methods
     // This rule aims to make code more readable and explicit about who can use which properties.
-    '@typescript-eslint/explicit-member-accessibility': 'warn',
-
-    // Require a specific member delimiter style for interfaces and type literals
-    // This rule aims to standardise the way interface and type literal members are delimited.
-    '@typescript-eslint/member-delimiter-style': ['warn', {
-      multiline: {
-        delimiter: 'none',
-      },
-      singleline: {
-        delimiter: 'comma',
-      },
+    '@typescript-eslint/explicit-member-accessibility': ['warn', {
+      accessibility: 'no-public',
     }],
 
     // Require a consistent member declaration order
     // A consistent ordering of fields, methods and constructors can make interfaces, type literals,
     // classes and class expressions easier to read, navigate and edit.
     '@typescript-eslint/member-ordering': 'warn',
-
-    // Enforces the use of `as Type` assertions instead of `<Type>` assertions
-    // This rule aims to standardise the use of type assertion style across the codebase.
-    '@typescript-eslint/no-angle-bracket-type-assertion': 'warn',
 
     // Disallow generic Array constructors
     // Use of the Array constructor to construct a new array is generally discouraged in favor of
@@ -115,6 +124,37 @@ module.exports = {
     // the type can be easily inferred from its value.
     '@typescript-eslint/no-explicit-any': 'warn',
 
+    // Forbids the use of classes as namespaces
+    // This rule warns when a class is accidentally used as a namespace.
+    '@typescript-eslint/no-extraneous-class': ['warn', {
+      allowConstructorOnly: true,
+    }],
+
+    // @TODO(semver-major): -> error
+    // Requires Promise-like values to be handled appropriately
+    // This rule forbids usage of Promise-like values in statements without handling their errors
+    // appropriately. Unhandled promises can cause several issues, such as improperly sequenced
+    // operations, ignored Promise rejections and more.
+    '@typescript-eslint/no-floating-promises': 'warn',
+
+    // @TODO(semver-major): -> error. The indexes are treated as strings!
+    // Disallow iterating over an array with a for-in loop
+    // A for-in loop (for (var k in o)) iterates over the properties of an Object. While it is legal
+    // to use for-in loops with array types, it is not common. for-in will iterate over the indices
+    // of the array as strings, omitting any "holes" in the array.
+    '@typescript-eslint/no-for-in-array': 'warn',
+
+    // @TODO(semver-major): -> error
+    // Enforce valid definition of new and constructor
+    // Warns on apparent attempts to define constructors for interfaces or new for classes.
+    '@typescript-eslint/no-misused-new': 'warn',
+
+    // @TODO(semver-major): -> error
+    // Avoid using promises in places not designed to handle them
+    // This rule forbids using promises in places where the Typescript compiler allows them but they
+    // are not handled properly. These situations can often arise due to a missing await keyword or
+    // just a misunderstanding of the way async functions are handled/awaited.
+    '@typescript-eslint/no-misused-promises': 'warn',
 
     // Disallow the use of custom TypeScript modules and namespaces
     // Custom TypeScript modules (module foo {}) and namespaces (namespace foo {}) are considered
@@ -131,14 +171,38 @@ module.exports = {
     // explicitly declare all properties in the class.
     '@typescript-eslint/no-parameter-properties': 'warn',
 
+    // Disallows invocation of require()
+    // Prefer the newer ES6-style imports over require().
+    '@typescript-eslint/no-require-imports': 'warn',
+
+    // Disallow aliasing this
+    // Assigning a variable to this instead of properly using arrow lambdas may be a symptom of
+    // pre-ES6 practices or not managing scope well.
+    '@typescript-eslint/no-this-alias': ['warn', {
+      allowDestructuring: true,
+    }],
+
+    // Warns when a namespace qualifier is unnecessary
+    // This rule aims to let users know when a namespace or enum qualifier is unnecessary, whether
+    // used for a type or for a value.
+    '@typescript-eslint/no-unnecessary-qualifier': 'warn',
+
+    // Warns if a type assertion does not change the type of an expression
+    // This rule aims to prevent unnecessary type assertions.
+    '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
+
     // Disallow /// <reference path="" /> comments
     // Triple-slash reference directive comments should not be used anymore. Use import instead.
-    '@typescript-eslint/no-triple-slash-reference': 'error',
+    '@typescript-eslint/triple-slash-reference': ['error', {
+      path: 'never',
+      types: 'never',
+      lib: 'never',
+    }],
 
     // Variables that are declared and not used anywhere in the code are most likely an error due
     // to incomplete refactoring. Such variables take up space in the code and can lead to
     // confusion by readers.
-    '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-unused-vars': base.rules['no-unused-vars'],
 
     // Disallow the use of variables before they are defined
     // This rule will warn when it encounters a reference to an identifier that has not yet been
@@ -154,6 +218,11 @@ module.exports = {
     // style imports or import foo = require("foo") imports.
     '@typescript-eslint/no-var-requires': 'error',
 
+    // Disallow unnecessary constructors
+    // This rule flags class constructors that can be safely removed without changing how the class
+    // works.
+    '@typescript-eslint/no-useless-constructor': base.rules['no-useless-constructor'],
+
     // Require the use of the namespace keyword instead of the module keyword to declare custom
     // TypeScript modules
     // In an effort to prevent further confusion between custom TypeScript modules and the new
@@ -161,9 +230,32 @@ module.exports = {
     // to declare custom TypeScript modules.
     '@typescript-eslint/prefer-namespace-keyword': 'warn',
 
-    // Require consistent spacing around type annotations
-    // This rule aims to enforce specific spacing patterns around type annotations and function
-    // types in type literals.
-    '@typescript-eslint/type-annotation-spacing': 'warn',
+    // Functions that return promises must be async
+
+    // Requires any function or method that returns a Promise to be marked async. Ensures that each
+    // function is only capable of:
+    // - returning a rejected promise, or
+    // - throwing an Error object
+    //
+    // In contrast, non-async Promise-returning functions are technically capable of either. Code
+    // that handles the results of those functions will often need to handle both cases, which can
+    // get complex.
+    '@typescript-eslint/promise-function-async': 'warn',
+
+    // Enforce giving compare argument to Array#sort
+    // This rule is aimed at preventing the calls of Array#sort method. This rule ignores the sort
+    // methods of user-defined types.
+    '@typescript-eslint/require-array-sort-compare': 'warn',
+
+    // Disallow async functions which have no await expression
+    '@typescript-eslint/require-await': base.rules['require-await'],
+
+    // @TODO(semver-major): -> error
+    // When adding two variables, operands must both be of type number or of type string
+    '@typescript-eslint/restrict-plus-operands': 'warn',
+
+    // Enforces unbound methods are called with their expected scope
+    // Class functions don't preserve the class scope when passed as standalone variables.
+    '@typescript-eslint/unbound-method': 'warn',
   },
 }

--- a/packages/eslint-config-typescript/package-lock.json
+++ b/packages/eslint-config-typescript/package-lock.json
@@ -15,45 +15,45 @@
 			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
-			"integrity": "sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
+			"integrity": "sha512-Mo45nxTTELODdl7CgpZKJISvLb+Fu64OOO2ZFc2x8sYSnUpFrBUW3H+H/ZGYmEkfnL6VkdtOSxgdt+Av79j0sA==",
 			"requires": {
-				"@typescript-eslint/experimental-utils": "1.13.0",
-				"eslint-utils": "^1.3.1",
+				"@typescript-eslint/experimental-utils": "2.0.0",
+				"eslint-utils": "^1.4.0",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^2.0.1",
-				"tsutils": "^3.7.0"
+				"tsutils": "^3.14.0"
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-			"integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.0.0.tgz",
+			"integrity": "sha512-XGJG6GNBXIEx/mN4eTRypN/EUmsd0VhVGQ1AG+WTgdvjHl0G8vHhVBHrd/5oI6RRYBRnedNymSYWW1HAdivtmg==",
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "1.13.0",
+				"@typescript-eslint/typescript-estree": "2.0.0",
 				"eslint-scope": "^4.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
-			"integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.0.0.tgz",
+			"integrity": "sha512-ibyMBMr0383ZKserIsp67+WnNVoM402HKkxqXGlxEZsXtnGGurbnY90pBO3e0nBUM7chEEOcxUhgw9aPq7fEBA==",
 			"requires": {
 				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "1.13.0",
-				"@typescript-eslint/typescript-estree": "1.13.0",
+				"@typescript-eslint/experimental-utils": "2.0.0",
+				"@typescript-eslint/typescript-estree": "2.0.0",
 				"eslint-visitor-keys": "^1.0.0"
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-			"integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.0.0.tgz",
+			"integrity": "sha512-NXbmzA3vWrSgavymlzMWNecgNOuiMMp62MO3kI7awZRLRcsA1QrYWo6q08m++uuAGVbXH/prZi2y1AWuhSu63w==",
 			"requires": {
 				"lodash.unescape": "4.0.1",
-				"semver": "5.5.0"
+				"semver": "^6.2.0"
 			}
 		},
 		"eslint-scope": {
@@ -107,9 +107,9 @@
 			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
 		},
 		"semver": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 		},
 		"tslib": {
 			"version": "1.10.0",

--- a/packages/eslint-config-typescript/package-lock.json
+++ b/packages/eslint-config-typescript/package-lock.json
@@ -14,6 +14,11 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
 			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
 		},
+		"@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
@@ -56,6 +61,29 @@
 				"semver": "^6.2.0"
 			}
 		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"deepmerge": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+			"integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+		},
+		"eslint-import-resolver-typescript": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-1.1.1.tgz",
+			"integrity": "sha512-jqSfumQ+H5y3FUJ6NjRkbOQSUOlbBucGTN3ELymOtcDBbPjVdm/luvJuCfCaIXGh8sEF26ma1qVdtDgl9ndhUg==",
+			"requires": {
+				"debug": "^4.0.1",
+				"resolve": "^1.4.0",
+				"tsconfig-paths": "^3.6.0"
+			}
+		},
 		"eslint-scope": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -96,20 +124,68 @@
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 		},
+		"json5": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"requires": {
+				"minimist": "^1.2.0"
+			}
+		},
 		"lodash.unescape": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
 			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"regexpp": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
 			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
 		},
+		"resolve": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+		},
+		"tsconfig-paths": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.8.0.tgz",
+			"integrity": "sha512-zZEYFo4sjORK8W58ENkRn9s+HmQFkkwydDG7My5s/fnfr2YYCaiyXe/HBUcIgU8epEKOXwiahOO+KZYjiXlWyQ==",
+			"requires": {
+				"@types/json5": "^0.0.29",
+				"deepmerge": "^2.0.1",
+				"json5": "^1.0.1",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
+			}
 		},
 		"tslib": {
 			"version": "1.10.0",

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -12,8 +12,8 @@
   ],
   "dependencies": {
     "@strv/eslint-config-base": "^2.0.0",
-    "@typescript-eslint/eslint-plugin": "^1.6.0",
-    "@typescript-eslint/parser": "^1.6.0"
+    "@typescript-eslint/eslint-plugin": "^2.0.0",
+    "@typescript-eslint/parser": "^2.0.0"
   },
   "engines": {
     "node": ">=10"

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@strv/eslint-config-base": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
-    "@typescript-eslint/parser": "^2.0.0"
+    "@typescript-eslint/parser": "^2.0.0",
+    "eslint-import-resolver-typescript": "^1.1.1"
   },
   "engines": {
     "node": ">=10"

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -22,7 +22,7 @@
   "keywords": [
     "config",
     "eslint",
-    "react",
+    "typescript",
     "strv"
   ],
   "license": "BSD-3-Clause",

--- a/packages/eslint-config-typescript/readme.md
+++ b/packages/eslint-config-typescript/readme.md
@@ -4,6 +4,16 @@
 
 These configuration files are suitable to lint TypeScript code.
 
+## Setup
+
+To lint TypeScript files using ESLint and this ruleset you must
+
+1. Install ESLint & this ruleset
+1. Tell the TypeScript parser where your _tsconfig.json_ file is (not doing so will cause some TS-syntax-specific rules to not work at all)
+1. Extend one or more of the included rulesets
+
+See the example _.eslintrc.js_ file below for more details and make sure you read the [Parser's docs][ts-parser-configuration] about its settings.
+
 ## Configurations
 
 ### `@strv/eslint-config-typescript`
@@ -43,6 +53,12 @@ module.exports = {
     '@strv/eslint-config-typescript',
     '@strv/eslint-config-typescript/style',
   ],
+
+  parserOptions: {
+    // The project field is required in order for some TS-syntax-specific rules to function at all
+    // @see https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#configuration
+    project: './tsconfig.json',
+  },
 }
 ```
 
@@ -64,7 +80,7 @@ The [vscode-eslint](https://github.com/Microsoft/vscode-eslint) plugin for integ
     { "language": "typescriptreact", "autoFix": true }
   ]
 ```
-> Notice we are adding `javascriptreact` and `typescriptreact` above. It won't harm adding those, but you can always omit this languages if not using them.
+> Notice we are adding `javascriptreact` and `typescriptreact` above. It won't harm adding those, but you can always omit these languages if not using them.
 
 ## License
 
@@ -72,3 +88,4 @@ See the [LICENSE](LICENSE) file for information.
 
 [eslint-config-node]: https://www.npmjs.com/package/@strv/eslint-config-node
 [eslint-config-react]: https://www.npmjs.com/package/@strv/eslint-config-react
+[ts-parser-configuration]: https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#configuration

--- a/packages/eslint-config-typescript/style.js
+++ b/packages/eslint-config-typescript/style.js
@@ -8,7 +8,117 @@
 
 'use strict'
 
+const style = require('@strv/eslint-config-base/style')
+
 module.exports = {
 
   extends: require.resolve('@strv/eslint-config-base/style'),
+
+  rules: {
+    // Conflicts with typescript
+    camelcase: 'off',
+    'func-call-spacing': 'off',
+    indent: 'off',
+    'no-extra-parens': 'off',
+    quotes: 'off',
+    semi: 'off',
+
+    // Enforce camelCase naming convention
+    '@typescript-eslint/camelcase': style.rules.camelcase,
+
+    // Enforces consistent usage of type assertions
+    // This rule aims to standardise the use of type assertion style across the codebase.
+    '@typescript-eslint/consistent-type-assertions': ['warn', {
+      assertionStyle: 'as',
+      objectLiteralTypeAssertions: 'allow-as-parameter',
+    }],
+
+    // Consistent type definition with either interface or type
+    // Interfaces are generally preferred over type literals because interfaces can be implemented,
+    // extended and merged.
+    '@typescript-eslint/consistent-type-definitions': ['warn', 'interface'],
+
+    // Require or disallow spacing between function identifiers and their invocations
+    // This rule extends the base eslint/func-call-spacing rule. It supports all options and
+    // features of the base rule. This version adds support for generic type parameters on function
+    // calls.
+    '@typescript-eslint/func-call-spacing': style.rules['func-call-spacing'],
+
+    // Enforce consistent indentation
+    '@typescript-eslint/indent': style.rules.indent,
+
+    // Require a specific member delimiter style for interfaces and type literals
+    // This rule aims to standardise the way interface and type literal members are delimited.
+    '@typescript-eslint/member-delimiter-style': ['warn', {
+      multiline: {
+        delimiter: 'none',
+      },
+      singleline: {
+        delimiter: 'comma',
+      },
+    }],
+
+    // disallow unnecessary parentheses
+    '@typescript-eslint/no-extra-parens': style.rules['no-extra-parens'],
+
+    // Disallows explicit type declarations for builtin primitive values
+    // This rule disallows explicit type declarations on parameters, variables and properties where
+    // the type can be easily inferred from its value.
+    '@typescript-eslint/no-inferrable-types': 'warn',
+
+    // Enforces that types will not to be used
+    // Warns if an explicitly specified type argument is the default for that type parameter.
+    '@typescript-eslint/no-unnecessary-type-arguments': 'warn',
+
+    // Use for-of loops instead of standard for loops over arrays
+    // This rule recommends a for-of loop when the loop index is only used to read from an array
+    // that is being iterated.
+    '@typescript-eslint/prefer-for-of': 'warn',
+
+    // Use function types instead of interfaces with call signatures
+    // This rule suggests using a function type instead of an interface or object type literal with
+    // a single call signature.
+    '@typescript-eslint/prefer-function-type': 'warn',
+
+    // Enforce includes method over indexOf method
+    // This rule is aimed at suggesting includes method if indexOf method was used to check whether
+    // an object contains an arbitrary value or not.
+    '@typescript-eslint/prefer-includes': 'warn',
+
+    // require never-modified private members be marked as readonly
+    // Member variables with the privacy private are never permitted to be modified outside of their
+    // declaring class. If that class never modifies their value, they may safely be marked as
+    // readonly.
+    '@typescript-eslint/prefer-readonly': 'warn',
+
+    // Enforce to use RegExp#exec over String#match
+    // This rule is aimed at enforcing the more performant way of applying regular expressions on
+    // strings.
+    '@typescript-eslint/prefer-regexp-exec': 'warn',
+
+    // Enforce the use of String#startsWith and String#endsWith
+    // This rule is aimed at enforcing a consistent way to check whether a string starts or ends
+    // with a specific string.
+    '@typescript-eslint/prefer-string-starts-ends-with': 'warn',
+
+    // Enforce the consistent use of either backticks, double, or single quotes
+    // This rule extends the base eslint/quotes rule. It supports all options and features of the
+    // base rule.
+    '@typescript-eslint/quotes': style.rules.quotes,
+
+    // Enforce or Disallow Semicolons
+    // This rule is aimed at ensuring consistent use of semicolons.
+    '@typescript-eslint/semi': style.rules.semi,
+
+    // Require consistent spacing around type annotations
+    // This rule aims to enforce specific spacing patterns around type annotations and function
+    // types in type literals.
+    '@typescript-eslint/type-annotation-spacing': 'warn',
+
+    // Warns for any two overloads that could be unified into one
+    // Warns for any two overloads that could be unified into one by using a union or an
+    // optional/rest parameter. This rule aims to keep the source code as maintanable as posible by
+    // reducing the amount of overloads.
+    '@typescript-eslint/unified-signatures': 'warn',
+  },
 }


### PR DESCRIPTION
The TypeScript ruleset really needs some more love which I have just gladly provided ❤️.

- the parser and plugin have been upgraded to version 2.0
- **all* rules and their settings have been revisited
  > The plugin now offers several extra rules which supersede the built-in ESLint rules, making them TS-aware. In turn, this means less false-positives/negatives. 🎉 
- Some conflicting settings from `@strv/eslint-config-node` have been fixed
  > ESLint will no longer blow up on every ES module import/export statement saying it's not supported
- The ruleset should now properly recognise and resolve your module aliases defined via `paths` in your _tsconfig.json_ file
- Documentation has been improved (this config **requires** some extra configuration in each project's _.eslintrc.js_ file ⚠️)

> Special thanks to @jzavisek for all the feedback from using the current version of the ruleset. ❤️ 