### PR TITLE
fix: update invalid cli option

### DIFF
--- a/packages/eslint-config-typescript/readme.md
+++ b/packages/eslint-config-typescript/readme.md
@@ -65,7 +65,7 @@ module.exports = {
 To actually lint .ts files, you must pass the `--ext` flag to ESLint:
 
 ```sh
-eslint --ext ts --no-unused-disable-directives .
+eslint --ext ts --report-unused-disable-directives .
 ```
 
 ## VSCode integration


### PR DESCRIPTION
Currently when running `eslint --ext ts --no-unused-disable-directives .` it throws an error `Invalid option '--unused-disable-directives' - perhaps you meant '--report-unused-disable-directives'?` 
`"eslint": "^6.4.0"`