### PR TITLE
Fix "@typescript-eslint/array-type" error

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -67,10 +67,7 @@ module.exports = {
 
     // Requires using either T[] or Array<T> for arrays
     // This rule aims to standardise usage of array types within your codebase.
-    '@typescript-eslint/array-type': ['warn', {
-      default: 'array-simple',
-      readonly: 'array-simple',
-    }],
+    '@typescript-eslint/array-type': ['warn', 'array-simple'],
 
     // Disallows awaiting a value that is not a Promise
     // This rule disallows awaiting a value that is not a "Thenable" (an object which has then


### PR DESCRIPTION
Fixes
```
Error: .eslintrc.js » @strv/eslint-config-typescript:
        Configuration for rule "@typescript-eslint/array-type" is invalid:
        Value {"default":"array-simple","readonly":"array-simple"} should be equal to one of the allowed values.
```

This is compatible with the current solution as `readonly` property gets set from `default`. More info here: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md