### PR TITLE
feat(eslint-typescript): be more strict with some rules

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -129,6 +129,11 @@ module.exports = {
     // indicator that some refactoring is likely needed.
     'no-empty': 'error',
 
+    // Disallow empty functions
+    // This rule is aimed at eliminating empty functions. A function will not be considered a
+    // problem if it contains a comment.
+    'no-empty-function': 'warn',
+
     // Disallow eval()
     // This rule is aimed at preventing potentially dangerous, unnecessary, and slow code by
     // disallowing the use of the eval() function.

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -157,7 +157,7 @@ module.exports = {
     // Disallow the delete operator with computed key expressions
     // Using the `delete` operator on keys that aren't runtime constants could be a sign that you're
     // using the wrong data structures.
-    '@typescript-eslint/no-dynamic-delete': 'warn',
+    '@typescript-eslint/no-dynamic-delete': 'error',
 
     // Disallow the declaration of empty interfaces
     // An empty interface is equivalent to its supertype. If the interface does not implement a
@@ -169,7 +169,7 @@ module.exports = {
     // string, or boolean
     // This rule disallows explicit type declarations on parameters, variables and properties where
     // the type can be easily inferred from its value.
-    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-explicit-any': 'error',
 
     // Disallow unnecessary semicolons
     '@typescript-eslint/no-extra-semi': base.rules['no-extra-semi'],
@@ -184,23 +184,26 @@ module.exports = {
       allowWithDecorator: true,
     }],
 
-    // @TODO(semver-major): -> error
     // Requires Promise-like values to be handled appropriately
     // This rule forbids usage of Promise-like values in statements without handling their errors
     // appropriately. Unhandled promises can cause several issues, such as improperly sequenced
     // operations, ignored Promise rejections and more.
-    '@typescript-eslint/no-floating-promises': 'warn',
+    '@typescript-eslint/no-floating-promises': 'error',
 
-    // @TODO(semver-major): -> error. The indexes are treated as strings!
     // Disallow iterating over an array with a for-in loop
     // A for-in loop (for (var k in o)) iterates over the properties of an Object. While it is legal
     // to use for-in loops with array types, it is not common. for-in will iterate over the indices
     // of the array as strings, omitting any "holes" in the array.
-    '@typescript-eslint/no-for-in-array': 'warn',
+    '@typescript-eslint/no-for-in-array': 'error',
 
     // Disallow the use of `eval()`-like methods
     '@typescript-eslint/no-implied-eval': base.rules['no-implied-eval'],
     'no-implied-eval': 'off',
+
+    // Disallows explicit type declarations for builtin primitive values
+    // This rule disallows explicit type declarations on parameters, variables and properties where
+    // the type can be easily inferred from its value.
+    '@typescript-eslint/no-inferrable-types': 'error',
 
     // Disallow `this` keywords outside of classes or class-like objects
     '@typescript-eslint/no-invalid-this': 'error',
@@ -264,7 +267,7 @@ module.exports = {
     // Disallow aliasing this
     // Assigning a variable to this instead of properly using arrow lambdas may be a symptom of
     // pre-ES6 practices or not managing scope well.
-    '@typescript-eslint/no-this-alias': ['warn', {
+    '@typescript-eslint/no-this-alias': ['error', {
       allowDestructuring: true,
     }],
 
@@ -354,9 +357,19 @@ module.exports = {
     // Prefer usage of `as const` over literal type
     '@typescript-eslint/prefer-as-const': 'warn',
 
+    // Use function types instead of interfaces with call signatures
+    // This rule suggests using a function type instead of an interface or object type literal with
+    // a single call signature.
+    '@typescript-eslint/prefer-function-type': 'error',
+
     // Require that all enum members be literal values to prevent unintended enum member name shadow
     // issues
     '@typescript-eslint/prefer-literal-enum-member': 'warn',
+
+    // Enforce the usage of the nullish coalescing operator instead of logical chaining
+    // TypeScript 3.7 added support for the nullish coalescing operator. This operator allows you to
+    // safely cascade a value when dealing with null or undefined.
+    '@typescript-eslint/prefer-nullish-coalescing': 'error',
 
     // Require the use of the namespace keyword instead of the module keyword to declare custom
     // TypeScript modules
@@ -383,9 +396,7 @@ module.exports = {
     // Enforce giving compare argument to Array#sort
     // This rule is aimed at preventing the calls of Array#sort method. This rule ignores the sort
     // methods of user-defined types.
-    '@typescript-eslint/require-array-sort-compare': ['warn', {
-      ignoreStringArrays: true,
-    }],
+    '@typescript-eslint/require-array-sort-compare': 'error',
 
     // Disallow async functions which have no await expression
     '@typescript-eslint/require-await': base.rules['require-await'],

--- a/packages/eslint-config-typescript/style.js
+++ b/packages/eslint-config-typescript/style.js
@@ -114,11 +114,6 @@ module.exports = {
     // Disallow extra non-null assertion
     '@typescript-eslint/no-extra-non-null-assertion': 'warn',
 
-    // Disallows explicit type declarations for builtin primitive values
-    // This rule disallows explicit type declarations on parameters, variables and properties where
-    // the type can be easily inferred from its value.
-    '@typescript-eslint/no-inferrable-types': 'warn',
-
     // Flags unnecessary equality comparisons against boolean literals
     // Comparing boolean values to boolean literals is unnecessary, those comparisons result in the
     // same booleans. Using the boolean values directly, or via a unary negation (`!value`), is more
@@ -145,32 +140,16 @@ module.exports = {
     // that is being iterated.
     '@typescript-eslint/prefer-for-of': 'warn',
 
-    // Use function types instead of interfaces with call signatures
-    // This rule suggests using a function type instead of an interface or object type literal with
-    // a single call signature.
-    '@typescript-eslint/prefer-function-type': 'warn',
-
     // Enforce includes method over indexOf method
     // This rule is aimed at suggesting includes method if indexOf method was used to check whether
     // an object contains an arbitrary value or not.
     '@typescript-eslint/prefer-includes': 'warn',
-
-    // Enforce the usage of the nullish coalescing operator instead of logical chaining
-    // TypeScript 3.7 added support for the nullish coalescing operator. This operator allows you to
-    // safely cascade a value when dealing with null or undefined.
-    '@typescript-eslint/prefer-nullish-coalescing': 'warn',
 
     // Prefer using concise optional chain expressions instead of chained logical ands
     // TypeScript 3.7 added support for the optional chain operator. This operator allows you to
     // safely access properties and methods on objects when they are potentially `null` or
     // `undefined`.
     '@typescript-eslint/prefer-optional-chain': 'warn',
-
-    // require never-modified private members be marked as readonly
-    // Member variables with the privacy private are never permitted to be modified outside of their
-    // declaring class. If that class never modifies their value, they may safely be marked as
-    // readonly.
-    '@typescript-eslint/prefer-readonly': 'warn',
 
     // Enforce to use RegExp#exec over String#match
     // This rule is aimed at enforcing the more performant way of applying regular expressions on


### PR DESCRIPTION
BREAKING CHANGE: Several rules' level has been raised to `error` after a long discussion with many team members. We feel that some code patterns are really dangerous and should be flagged appropriately, even if we recognise that there might be some small, valid use-cases for some of them. The rules include:

- no-explicit-any: if you don't know the type then use `unknown` instead
- no-dynamic-delete: if you need to dynamically remove properties from an object then perhaps you should use a different data store, like `Map` or `Set`
- no-floating-promises: always, always! handle promises, at least add a `.catch(err => console.error(err)` to them
- no-for-in-array: always prefer `for-of` loop or other iteration mechanism
- no-inferrable-types: save your keyboard from all these unnecessary keystrokes required to add types to variables which are obvious
- no-this-alias: don't assign `this` to a variable; use an arrow function instead
- prefer-function-type: makes code more readable in some specific situations
- prefer-nullish-coalescing: it is far superior to other logical operators
- require-array-sort-compare: `Array.prototype.sort()` has a very basic default comparison logic so it's always preferred to provide explicit sorting rules.