### PR TITLE
feat(eslint-base): enforce json extension on imports

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -639,7 +639,7 @@ module.exports = {
     'import/export': 'error',
 
     // Ensure consistent use of file extension within the import path
-    'import/extensions': ['warn', 'never'],
+    'import/extensions': ['warn', { json: 'aways' }],
 
     // Reports if a module's default export is unnamed
     // Ensuring that default exports are named helps improve the grepability of the codebase by


### PR DESCRIPTION
@robertrossmann @MichalKlacko is it common on backend to import json files without extension? Otherwise, I would move ahead with this one.